### PR TITLE
Added (incomplete) motion controls emulation support.

### DIFF
--- a/src/Ryujinx.Common/Configuration/Hid/Controller/Motion/MotionConfigController.cs
+++ b/src/Ryujinx.Common/Configuration/Hid/Controller/Motion/MotionConfigController.cs
@@ -21,5 +21,10 @@ namespace Ryujinx.Common.Configuration.Hid.Controller.Motion
         /// Enable Motion Controls
         /// </summary>
         public bool EnableMotion { get; set; }
+
+        /// <summary>
+        /// Enable translating sticks to motion controls.
+        /// </summary>
+        public bool SticksToMotion { get; set; }
     }
 }

--- a/src/Ryujinx.Common/Configuration/Hid/KeyboardHotkeys.cs
+++ b/src/Ryujinx.Common/Configuration/Hid/KeyboardHotkeys.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Ryujinx.Common.Configuration.Hid
 {
     public class KeyboardHotkeys
@@ -11,5 +13,6 @@ namespace Ryujinx.Common.Configuration.Hid
         public Key ResScaleDown { get; set; }
         public Key VolumeUp { get; set; }
         public Key VolumeDown { get; set; }
+        public Key ToggleMotionEmulation { get; set; }
     }
 }

--- a/src/Ryujinx.Gtk3/Input/GTK3/GTK3Keyboard.cs
+++ b/src/Ryujinx.Gtk3/Input/GTK3/GTK3Keyboard.cs
@@ -95,7 +95,7 @@ namespace Ryujinx.Input.GTK3
             return ((short)(stick.X * short.MaxValue), (short)(stick.Y * short.MaxValue));
         }
 
-        public GamepadStateSnapshot GetMappedStateSnapshot()
+        public GamepadStateSnapshot GetMappedStateSnapshot(bool _)
         {
             KeyboardStateSnapshot rawState = GetKeyboardStateSnapshot();
             GamepadStateSnapshot result = default;
@@ -131,7 +131,7 @@ namespace Ryujinx.Input.GTK3
             return result;
         }
 
-        public GamepadStateSnapshot GetStateSnapshot()
+        public GamepadStateSnapshot GetStateSnapshot(bool _)
         {
             throw new NotSupportedException();
         }

--- a/src/Ryujinx.Gtk3/Input/GTK3/GTK3Mouse.cs
+++ b/src/Ryujinx.Gtk3/Input/GTK3/GTK3Mouse.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Input.GTK3
             return _driver.Scroll;
         }
 
-        public GamepadStateSnapshot GetMappedStateSnapshot()
+        public GamepadStateSnapshot GetMappedStateSnapshot(bool _)
         {
             throw new NotImplementedException();
         }
@@ -46,7 +46,7 @@ namespace Ryujinx.Input.GTK3
             throw new NotImplementedException();
         }
 
-        public GamepadStateSnapshot GetStateSnapshot()
+        public GamepadStateSnapshot GetStateSnapshot(bool _)
         {
             throw new NotImplementedException();
         }

--- a/src/Ryujinx.Headless.SDL2/SDL2Mouse.cs
+++ b/src/Ryujinx.Headless.SDL2/SDL2Mouse.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Headless.SDL2
             return _driver.Scroll;
         }
 
-        public GamepadStateSnapshot GetMappedStateSnapshot()
+        public GamepadStateSnapshot GetMappedStateSnapshot(bool _)
         {
             throw new NotImplementedException();
         }
@@ -47,7 +47,7 @@ namespace Ryujinx.Headless.SDL2
             throw new NotImplementedException();
         }
 
-        public GamepadStateSnapshot GetStateSnapshot()
+        public GamepadStateSnapshot GetStateSnapshot(bool _)
         {
             throw new NotImplementedException();
         }

--- a/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
@@ -265,14 +265,14 @@ namespace Ryujinx.Input.SDL2
             }
         }
 
-        public GamepadStateSnapshot GetStateSnapshot()
+        public GamepadStateSnapshot GetStateSnapshot(bool ignoreSticks)
         {
-            return IGamepad.GetStateSnapshot(this);
+            return IGamepad.GetStateSnapshot(this, ignoreSticks);
         }
 
-        public GamepadStateSnapshot GetMappedStateSnapshot()
+        public GamepadStateSnapshot GetMappedStateSnapshot(bool ignoreSticks)
         {
-            GamepadStateSnapshot rawState = GetStateSnapshot();
+            GamepadStateSnapshot rawState = GetStateSnapshot(ignoreSticks);
             GamepadStateSnapshot result = default;
 
             lock (_userMappingLock)

--- a/src/Ryujinx.Input.SDL2/SDL2Keyboard.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Keyboard.cs
@@ -299,7 +299,7 @@ namespace Ryujinx.Input.SDL2
             return ((short)(stick.X * short.MaxValue), (short)(stick.Y * short.MaxValue));
         }
 
-        public GamepadStateSnapshot GetMappedStateSnapshot()
+        public GamepadStateSnapshot GetMappedStateSnapshot(bool _)
         {
             KeyboardStateSnapshot rawState = GetKeyboardStateSnapshot();
             GamepadStateSnapshot result = default;
@@ -335,7 +335,7 @@ namespace Ryujinx.Input.SDL2
             return result;
         }
 
-        public GamepadStateSnapshot GetStateSnapshot()
+        public GamepadStateSnapshot GetStateSnapshot(bool _)
         {
             throw new NotSupportedException();
         }

--- a/src/Ryujinx.Input/Assigner/GamepadButtonAssigner.cs
+++ b/src/Ryujinx.Input/Assigner/GamepadButtonAssigner.cs
@@ -33,7 +33,7 @@ namespace Ryujinx.Input.Assigner
         {
             if (_gamepad != null)
             {
-                _currState = _gamepad.GetStateSnapshot();
+                _currState = _gamepad.GetStateSnapshot(false);
                 _prevState = _currState;
             }
         }
@@ -43,7 +43,7 @@ namespace Ryujinx.Input.Assigner
             if (_gamepad != null)
             {
                 _prevState = _currState;
-                _currState = _gamepad.GetStateSnapshot();
+                _currState = _gamepad.GetStateSnapshot(false);
             }
 
             CollectButtonStats();

--- a/src/Ryujinx.Input/HLE/NpadManager.cs
+++ b/src/Ryujinx.Input/HLE/NpadManager.cs
@@ -50,6 +50,8 @@ namespace Ryujinx.Input.HLE
             _gamepadDriver.OnGamepadDisconnected += HandleOnGamepadDisconnected;
         }
 
+        public IEnumerable<NpadController> Controllers => _controllers;
+
         private void RefreshInputConfigForHLE()
         {
             lock (_lock)

--- a/src/Ryujinx.Input/IGamepad.cs
+++ b/src/Ryujinx.Input/IGamepad.cs
@@ -77,35 +77,39 @@ namespace Ryujinx.Input
         /// Get a snaphost of the state of the gamepad that is remapped with the informations from the <see cref="InputConfig"/> set via <see cref="SetConfiguration(InputConfig)"/>.
         /// </summary>
         /// <returns>A remapped snaphost of the state of the gamepad.</returns>
-        GamepadStateSnapshot GetMappedStateSnapshot();
+        GamepadStateSnapshot GetMappedStateSnapshot(bool ignoreSticks);
 
         /// <summary>
         /// Get a snaphost of the state of the gamepad.
         /// </summary>
         /// <returns>A snaphost of the state of the gamepad.</returns>
-        GamepadStateSnapshot GetStateSnapshot();
+        GamepadStateSnapshot GetStateSnapshot(bool ignoreSticks);
 
         /// <summary>
         /// Get a snaphost of the state of a gamepad.
         /// </summary>
         /// <param name="gamepad">The gamepad to do a snapshot of</param>
+        /// <param name="ignoreSticks">Forces the stick states to zero</param>
         /// <returns>A snaphost of the state of the gamepad.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static GamepadStateSnapshot GetStateSnapshot(IGamepad gamepad)
+        static GamepadStateSnapshot GetStateSnapshot(IGamepad gamepad, bool ignoreSticks)
         {
             // NOTE: Update Array size if JoystickInputId is changed.
             Array3<Array2<float>> joysticksState = default;
 
-            for (StickInputId inputId = StickInputId.Left; inputId < StickInputId.Count; inputId++)
+            if (!ignoreSticks)
             {
-                (float state0, float state1) = gamepad.GetStick(inputId);
+                for (StickInputId inputId = StickInputId.Left; inputId < StickInputId.Count; inputId++)
+                {
+                    (float state0, float state1) = gamepad.GetStick(inputId);
 
-                Array2<float> state = default;
+                    Array2<float> state = default;
 
-                state[0] = state0;
-                state[1] = state1;
+                    state[0] = state0;
+                    state[1] = state1;
 
-                joysticksState[(int)inputId] = state;
+                    joysticksState[(int)inputId] = state;
+                }
             }
 
             // NOTE: Update Array size if GamepadInputId is changed.

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -1200,6 +1200,14 @@ namespace Ryujinx.Ava
 
                             _viewModel.Volume = Device.GetVolume();
                             break;
+                        case KeyboardHotkeyState.ToggleMotionEmulation:
+                            foreach (var controller in NpadManager.Controllers)
+                            {
+                                var motion = controller?.StandardControllerInputConfig?.Motion;
+                                if (motion != null)
+                                    motion.SticksToMotion = !motion.SticksToMotion;
+                            }
+                            break;
                         case KeyboardHotkeyState.None:
                             (_keyboardInterface as AvaloniaKeyboard).Clear();
                             break;
@@ -1272,6 +1280,10 @@ namespace Ryujinx.Ava
             else if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.VolumeDown))
             {
                 state = KeyboardHotkeyState.VolumeDown;
+            }
+            else if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.ToggleMotionEmulation))
+            {
+                state = KeyboardHotkeyState.ToggleMotionEmulation;
             }
 
             return state;

--- a/src/Ryujinx/Assets/Locales/ar_SA.json
+++ b/src/Ryujinx/Assets/Locales/ar_SA.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "هل تريد تحديث ريوجينكس إلى أحدث إصدار؟",
   "SettingsTabHotkeysVolumeUpHotkey": "زيادة مستوى الصوت:",
   "SettingsTabHotkeysVolumeDownHotkey": "خفض مستوى الصوت:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "تمكين Maro HLE",
   "SettingsEnableMacroHLETooltip": "محاكاة عالية المستوى لكود مايكرو وحدة معالجة الرسوميات.\n\nيعمل على تحسين الأداء، ولكنه قد يسبب خللا رسوميا في بعض الألعاب.\n\nاتركه مفعلا إذا لم تكن متأكدا.",
   "SettingsEnableColorSpacePassthrough": "عبور مساحة اللون",

--- a/src/Ryujinx/Assets/Locales/de_DE.json
+++ b/src/Ryujinx/Assets/Locales/de_DE.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "Möchtest du Ryujinx auf die neueste Version aktualisieren?",
   "SettingsTabHotkeysVolumeUpHotkey": "Lautstärke erhöhen:",
   "SettingsTabHotkeysVolumeDownHotkey": "Lautstärke verringern:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "HLE Makros aktivieren",
   "SettingsEnableMacroHLETooltip": "High-Level-Emulation von GPU-Makrocode.\n\nVerbessert die Leistung, kann aber in einigen Spielen zu Grafikfehlern führen.\n\nBei Unsicherheit AKTIVIEREN.",
   "SettingsEnableColorSpacePassthrough": "Farbraum Passthrough",

--- a/src/Ryujinx/Assets/Locales/el_GR.json
+++ b/src/Ryujinx/Assets/Locales/el_GR.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "Θέλετε να ενημερώσετε το Ryujinx στην πιο πρόσφατη έκδοση:",
   "SettingsTabHotkeysVolumeUpHotkey": "Αύξηση Έντασης:",
   "SettingsTabHotkeysVolumeDownHotkey": "Μείωση Έντασης:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "Ενεργοποίηση του Macro HLE",
   "SettingsEnableMacroHLETooltip": "Προσομοίωση του κώδικα GPU Macro .\n\nΒελτιώνει την απόδοση, αλλά μπορεί να προκαλέσει γραφικά προβλήματα σε μερικά παιχνίδια.\n\nΑφήστε ΕΝΕΡΓΟ αν δεν είστε σίγουροι.",
   "SettingsEnableColorSpacePassthrough": "Διέλευση Χρωματικού Χώρου",

--- a/src/Ryujinx/Assets/Locales/en_US.json
+++ b/src/Ryujinx/Assets/Locales/en_US.json
@@ -753,6 +753,7 @@
   "RyujinxUpdaterMessage": "Do you want to update Ryujinx to the latest version?",
   "SettingsTabHotkeysVolumeUpHotkey": "Increase Volume:",
   "SettingsTabHotkeysVolumeDownHotkey": "Decrease Volume:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "Enable Macro HLE",
   "SettingsEnableMacroHLETooltip": "High-level emulation of GPU Macro code.\n\nImproves performance, but may cause graphical glitches in some games.\n\nLeave ON if unsure.",
   "SettingsEnableColorSpacePassthrough": "Color Space Passthrough",

--- a/src/Ryujinx/Assets/Locales/es_ES.json
+++ b/src/Ryujinx/Assets/Locales/es_ES.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "¿Quieres actualizar Ryujinx a la última versión?",
   "SettingsTabHotkeysVolumeUpHotkey": "Aumentar volumen:",
   "SettingsTabHotkeysVolumeDownHotkey": "Disminuir volumen:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Activar emulación de movimiento:",
   "SettingsEnableMacroHLE": "Activar Macros HLE",
   "SettingsEnableMacroHLETooltip": "Emulación alto-nivel del código de Macros de GPU\n\nIncrementa el rendimiento, pero puede causar errores gráficos en algunos juegos.\n\nDeja esta opción activada si no estás seguro.",
   "SettingsEnableColorSpacePassthrough": "Paso de espacio de color",

--- a/src/Ryujinx/Assets/Locales/fr_FR.json
+++ b/src/Ryujinx/Assets/Locales/fr_FR.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "Voulez-vous mettre à jour Ryujinx vers la dernière version ?",
   "SettingsTabHotkeysVolumeUpHotkey": "Augmenter le volume :",
   "SettingsTabHotkeysVolumeDownHotkey": "Diminuer le volume :",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "Activer les macros HLE",
   "SettingsEnableMacroHLETooltip": "Émulation de haut niveau du code de Macro GPU.\n\nAméliore les performances, mais peut causer des artefacts graphiques dans certains jeux.\n\nLaissez ACTIVER si vous n'êtes pas sûr.",
   "SettingsEnableColorSpacePassthrough": "Traversée de l'espace colorimétrique",

--- a/src/Ryujinx/Assets/Locales/he_IL.json
+++ b/src/Ryujinx/Assets/Locales/he_IL.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "האם ברצונך לעדכן את ריוג'ינקס לגרסא האחרונה?",
   "SettingsTabHotkeysVolumeUpHotkey": "הגבר את עוצמת הקול:",
   "SettingsTabHotkeysVolumeDownHotkey": "הנמך את עוצמת הקול:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "Enable Macro HLE",
   "SettingsEnableMacroHLETooltip": "אמולצייה ברמה גבוהה של כרטיס גראפי עם קוד מקרו.\n\nמשפר את ביצועי היישום אך עלול לגרום לגליצ'ים חזותיים במשחקים מסויימים.\n\nמוטב להשאיר דלוק אם אינך בטוח.",
   "SettingsEnableColorSpacePassthrough": "שקיפות מרחב צבע",

--- a/src/Ryujinx/Assets/Locales/it_IT.json
+++ b/src/Ryujinx/Assets/Locales/it_IT.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "Vuoi aggiornare Ryujinx all'ultima versione?",
   "SettingsTabHotkeysVolumeUpHotkey": "Alza il volume:",
   "SettingsTabHotkeysVolumeDownHotkey": "Abbassa il volume:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "Attiva HLE macro",
   "SettingsEnableMacroHLETooltip": "Emulazione di alto livello del codice macro della GPU.\n\nMigliora le prestazioni, ma può causare anomalie grafiche in alcuni giochi.\n\nNel dubbio, lascia l'opzione attiva.",
   "SettingsEnableColorSpacePassthrough": "Passthrough dello spazio dei colori",

--- a/src/Ryujinx/Assets/Locales/ja_JP.json
+++ b/src/Ryujinx/Assets/Locales/ja_JP.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "Ryujinx を最新版にアップデートしますか?",
   "SettingsTabHotkeysVolumeUpHotkey": "音量を上げる:",
   "SettingsTabHotkeysVolumeDownHotkey": "音量を下げる:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "マクロの高レベルエミュレーション (HLE) を有効にする",
   "SettingsEnableMacroHLETooltip": "GPU マクロコードの高レベルエミュレーションです.\n\nパフォーマンスを向上させますが, 一部のゲームでグラフィックに不具合が発生する可能性があります.\n\nよくわからない場合はオンのままにしてください.",
   "SettingsEnableColorSpacePassthrough": "色空間をパススルー",

--- a/src/Ryujinx/Assets/Locales/ko_KR.json
+++ b/src/Ryujinx/Assets/Locales/ko_KR.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "Ryujinx를 최신 버전으로 업데이트하겠습니까?",
   "SettingsTabHotkeysVolumeUpHotkey": "음량 증가 :",
   "SettingsTabHotkeysVolumeDownHotkey": "음량 감소 :",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "매크로 HLE 활성화",
   "SettingsEnableMacroHLETooltip": "GPU 매크로 코드의 높은 수준 에뮬레이션입니다.\n\n성능이 향상되지만 일부 게임에서 그래픽 결함이 발생할 수 있습니다.\n\n확실하지 않으면 켜 두세요.",
   "SettingsEnableColorSpacePassthrough": "색 공간 통과",

--- a/src/Ryujinx/Assets/Locales/pl_PL.json
+++ b/src/Ryujinx/Assets/Locales/pl_PL.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "Czy chcesz zaktualizować Ryujinx do najnowszej wersji?",
   "SettingsTabHotkeysVolumeUpHotkey": "Zwiększ Głośność:",
   "SettingsTabHotkeysVolumeDownHotkey": "Zmniejsz Głośność:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "Włącz Macro HLE",
   "SettingsEnableMacroHLETooltip": "Wysokopoziomowa emulacja kodu GPU Macro.\n\nPoprawia wydajność, ale może powodować błędy graficzne w niektórych grach.\n\nW razie wątpliwości pozostaw WŁĄCZONE.",
   "SettingsEnableColorSpacePassthrough": "Przekazywanie przestrzeni kolorów",

--- a/src/Ryujinx/Assets/Locales/pt_BR.json
+++ b/src/Ryujinx/Assets/Locales/pt_BR.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "Você quer atualizar o Ryujinx para a última versão?",
   "SettingsTabHotkeysVolumeUpHotkey": "Aumentar volume:",
   "SettingsTabHotkeysVolumeDownHotkey": "Diminuir volume:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "Habilitar emulação de alto nível para Macros",
   "SettingsEnableMacroHLETooltip": "Habilita emulação de alto nível de códigos Macro da GPU.\n\nMelhora a performance, mas pode causar problemas gráficos em alguns jogos.\n\nEm caso de dúvida, deixe ATIVADO.",
   "SettingsEnableColorSpacePassthrough": "Passagem de Espaço Cor",

--- a/src/Ryujinx/Assets/Locales/ru_RU.json
+++ b/src/Ryujinx/Assets/Locales/ru_RU.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "Обновить Ryujinx до последней версии?",
   "SettingsTabHotkeysVolumeUpHotkey": "Увеличить громкость:",
   "SettingsTabHotkeysVolumeDownHotkey": "Уменьшить громкость:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "Использовать макрос высокоуровневой эмуляции видеоадаптера",
   "SettingsEnableMacroHLETooltip": "Высокоуровневая эмуляции макрокода видеоадаптера.\n\nПовышает производительность, но может вызывать графические артефакты в некоторых играх.\n\nРекомендуется оставить включенным.",
   "SettingsEnableColorSpacePassthrough": "Пропускать цветовое пространство",

--- a/src/Ryujinx/Assets/Locales/th_TH.json
+++ b/src/Ryujinx/Assets/Locales/th_TH.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "คุณต้องการอัพเดต รียูจินซ์ เป็นเวอร์ชั่นล่าสุดหรือไม่?",
   "SettingsTabHotkeysVolumeUpHotkey": "เพิ่มระดับเสียง:",
   "SettingsTabHotkeysVolumeDownHotkey": "ลดระดับเสียง:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "เปิดใช้งาน มาโคร HLE",
   "SettingsEnableMacroHLETooltip": "การจำลองระดับสูงของโค้ดมาโคร GPU\n\nปรับปรุงประสิทธิภาพ แต่อาจทำให้เกิดข้อผิดพลาดด้านกราฟิกในบางเกม\n\nปล่อยไว้หากคุณไม่แน่ใจ",
   "SettingsEnableColorSpacePassthrough": "ทะลุผ่านพื้นที่สี",

--- a/src/Ryujinx/Assets/Locales/tr_TR.json
+++ b/src/Ryujinx/Assets/Locales/tr_TR.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "Ryujinx'i en son sürüme güncellemek ister misiniz?",
   "SettingsTabHotkeysVolumeUpHotkey": "Sesi Arttır:",
   "SettingsTabHotkeysVolumeDownHotkey": "Sesi Azalt:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "Macro HLE'yi Aktifleştir",
   "SettingsEnableMacroHLETooltip": "GPU Macro kodunun yüksek seviye emülasyonu.\n\nPerformansı arttırır, ama bazı oyunlarda grafik hatalarına yol açabilir.\n\nEmin değilseniz AÇIK bırakın.",
   "SettingsEnableColorSpacePassthrough": "Renk Alanı Geçişi",

--- a/src/Ryujinx/Assets/Locales/uk_UA.json
+++ b/src/Ryujinx/Assets/Locales/uk_UA.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "Бажаєте оновити Ryujinx до останньої версії?",
   "SettingsTabHotkeysVolumeUpHotkey": "Збільшити гучність:",
   "SettingsTabHotkeysVolumeDownHotkey": "Зменшити гучність:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "Увімкнути макрос HLE",
   "SettingsEnableMacroHLETooltip": "Високорівнева емуляція коду макросу GPU.\n\nПокращує продуктивність, але може викликати графічні збої в деяких іграх.\n\nЗалиште увімкненим, якщо не впевнені.",
   "SettingsEnableColorSpacePassthrough": "Наскрізний колірний простір",

--- a/src/Ryujinx/Assets/Locales/zh_CN.json
+++ b/src/Ryujinx/Assets/Locales/zh_CN.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "是否更新 Ryujinx 到最新的版本？",
   "SettingsTabHotkeysVolumeUpHotkey": "音量加：",
   "SettingsTabHotkeysVolumeDownHotkey": "音量减：",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "启用 HLE 宏加速",
   "SettingsEnableMacroHLETooltip": "GPU 宏指令的高级模拟。\n\n提高性能表现，但一些游戏可能会出现图形错误。\n\n如果不确定，请保持开启状态。",
   "SettingsEnableColorSpacePassthrough": "色彩空间直通",

--- a/src/Ryujinx/Assets/Locales/zh_TW.json
+++ b/src/Ryujinx/Assets/Locales/zh_TW.json
@@ -734,6 +734,7 @@
   "RyujinxUpdaterMessage": "您想將 Ryujinx 升級到最新版本嗎?",
   "SettingsTabHotkeysVolumeUpHotkey": "提高音量:",
   "SettingsTabHotkeysVolumeDownHotkey": "降低音量:",
+  "SettingsTabHotkeysToggleMotionEmulationHotkey": "Toggle Motion Emulation:",
   "SettingsEnableMacroHLE": "啟用 Macro HLE",
   "SettingsEnableMacroHLETooltip": "GPU 巨集程式碼的進階模擬。\n\n可提高效能，但在某些遊戲中可能會導致圖形閃爍。\n\n如果不確定，請保持開啟狀態。",
   "SettingsEnableColorSpacePassthrough": "色彩空間直通",

--- a/src/Ryujinx/Common/KeyboardHotkeyState.cs
+++ b/src/Ryujinx/Common/KeyboardHotkeyState.cs
@@ -12,5 +12,6 @@ namespace Ryujinx.Ava.Common
         ResScaleDown,
         VolumeUp,
         VolumeDown,
+        ToggleMotionEmulation,
     }
 }

--- a/src/Ryujinx/Input/AvaloniaKeyboard.cs
+++ b/src/Ryujinx/Input/AvaloniaKeyboard.cs
@@ -49,7 +49,7 @@ namespace Ryujinx.Ava.Input
             return IKeyboard.GetStateSnapshot(this);
         }
 
-        public GamepadStateSnapshot GetMappedStateSnapshot()
+        public GamepadStateSnapshot GetMappedStateSnapshot(bool _)
         {
             KeyboardStateSnapshot rawState = GetKeyboardStateSnapshot();
             GamepadStateSnapshot result = default;
@@ -85,7 +85,7 @@ namespace Ryujinx.Ava.Input
             return result;
         }
 
-        public GamepadStateSnapshot GetStateSnapshot()
+        public GamepadStateSnapshot GetStateSnapshot(bool _)
         {
             throw new NotSupportedException();
         }

--- a/src/Ryujinx/Input/AvaloniaMouse.cs
+++ b/src/Ryujinx/Input/AvaloniaMouse.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Ava.Input
             return _driver.Scroll;
         }
 
-        public GamepadStateSnapshot GetMappedStateSnapshot()
+        public GamepadStateSnapshot GetMappedStateSnapshot(bool _)
         {
             throw new NotImplementedException();
         }
@@ -44,7 +44,7 @@ namespace Ryujinx.Ava.Input
             throw new NotImplementedException();
         }
 
-        public GamepadStateSnapshot GetStateSnapshot()
+        public GamepadStateSnapshot GetStateSnapshot(bool _)
         {
             throw new NotImplementedException();
         }

--- a/src/Ryujinx/UI/Models/Input/HotkeyConfig.cs
+++ b/src/Ryujinx/UI/Models/Input/HotkeyConfig.cs
@@ -104,6 +104,17 @@ namespace Ryujinx.Ava.UI.Models.Input
             }
         }
 
+        private Key _toggleMotionEmulation;
+        public Key ToggleMotionEmulation
+        {
+            get => _toggleMotionEmulation;
+            set
+            {
+                _toggleMotionEmulation = value;
+                OnPropertyChanged();
+            }
+        }
+
         public HotkeyConfig(KeyboardHotkeys config)
         {
             if (config != null)
@@ -117,6 +128,7 @@ namespace Ryujinx.Ava.UI.Models.Input
                 ResScaleDown = config.ResScaleDown;
                 VolumeUp = config.VolumeUp;
                 VolumeDown = config.VolumeDown;
+                ToggleMotionEmulation = config.ToggleMotionEmulation;
             }
         }
 
@@ -133,6 +145,7 @@ namespace Ryujinx.Ava.UI.Models.Input
                 ResScaleDown = ResScaleDown,
                 VolumeUp = VolumeUp,
                 VolumeDown = VolumeDown,
+                ToggleMotionEmulation = ToggleMotionEmulation,
             };
 
             return config;

--- a/src/Ryujinx/UI/Views/Settings/SettingsHotkeysView.axaml
+++ b/src/Ryujinx/UI/Views/Settings/SettingsHotkeysView.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="Ryujinx.Ava.UI.Views.Settings.SettingsHotkeysView"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -101,6 +101,12 @@
                     <TextBlock Text="{locale:Locale SettingsTabHotkeysVolumeDownHotkey}" />
                     <ToggleButton Name="VolumeDown">
                         <TextBlock Text="{Binding KeyboardHotkey.VolumeDown, Converter={StaticResource Key}}" />
+                    </ToggleButton>
+                </StackPanel>
+                <StackPanel>
+                    <TextBlock Text="{locale:Locale SettingsTabHotkeysToggleMotionEmulationHotkey}" />
+                    <ToggleButton Name="ToggleMotionEmulation">
+                        <TextBlock Text="{Binding KeyboardHotkey.ToggleMotionEmulation, Converter={StaticResource Key}}" />
                     </ToggleButton>
                 </StackPanel>
             </StackPanel>

--- a/src/Ryujinx/UI/Views/Settings/SettingsHotkeysView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Settings/SettingsHotkeysView.axaml.cs
@@ -109,6 +109,9 @@ namespace Ryujinx.Ava.UI.Views.Settings
                                     case "VolumeDown":
                                         viewModel.KeyboardHotkey.VolumeDown = buttonValue.AsHidType<Key>();
                                         break;
+                                    case "ToggleMotionEmulation":
+                                        viewModel.KeyboardHotkey.ToggleMotionEmulation = buttonValue.AsHidType<Key>();
+                                        break;
                                 }
                             }
                         };


### PR DESCRIPTION
This adds a new keyboard shortcut (unbound by default) that when pressed toggles the emulator to interpret the analog sticks as combined gyro and accelerometer inputs. Roughly speaking:

Left stick horizontal: Like rocking the controller side to side (stick right -> controller tilted right).
Left stick vertical: Like rocking the controller forward and back (stick up -> controller tilted forward [or pitched down])
Right stick horizontal: Like rotating the controller around an axis parallel to the analog sticks (i.e. changes the yaw) (stick right -> controller rotates North to East)
Right stick vertical: No function

It's difficult to control and really not practical for any action gameplay, but it's workable for puzzles, and if you don't have a controller with motion sensors it's better than nothing. I managed to use this to solve a couple shrines in BotW.

TODO:
* A better translation algorithm? I wasn't really sure how to translate the inputs into what the Switch expects. See notes below.
* Sensibility settings, and possibly better control curves. I've had trouble finding a sensibility that gave both precision and quick movements.
* The toggle affects all connected controllers. I would have liked to be able to bind a button per controller, but the controller may not even have any buttons left after binding them for the normal controls.
* Right now the toggle state is persistent and stored as a setting. It should probably be volatile.
* The UI translations for the shortcut are missing, except for English and Spanish.

Notes:
If someone else wants to tackle the input translation, after some experimentation I figured out that the Switch's coordinate system is right-handed, with X to the right, Y forward, and Z up (relative to the controller when it's lying flat on the floor). When the controller is at rest, the accelerometer vector is the direction of gravity ((0, 0, -1) seems to work for a neutral position). The gyroscope values are angular velocities, and since the coordinate system rotates with the controller, specifying these values is usually simple. Note that in my experimentation, it seems gyroscope changes without accelerometer changes are often ignored; ideally moving any stick in any single axis should change both gyroscope and accelerometer in an integrated fashion. Finally, I'm not sure about the units. I think the accelerometer may be in g (1 = 9.8 m/s^2). The gyroscope could be in deg/s, but not sure.